### PR TITLE
Autocompletion: Add trailing space back

### DIFF
--- a/tool/bash/config_autocomplete.sh
+++ b/tool/bash/config_autocomplete.sh
@@ -36,8 +36,9 @@ __gamer_configure_autocomplete() {
 
     __gamer_check_gamer_info $configure_filename
 
-    # Not the GAEMR `configure.py`
+    # Not the GAEMR `configure.py`, fallback to default.
     if [ $? -ne 0 ]; then
+        compopt -o default +o nospace
         return 0
     fi
 
@@ -90,6 +91,4 @@ __gamer_configure_autocomplete() {
 
 } # __gamer_configure_autocomplete()
 
-complete -o default -o nospace -F __gamer_configure_autocomplete ./configure.py
-complete -o default -o nospace -F __gamer_configure_autocomplete python
-complete -o default -o nospace -F __gamer_configure_autocomplete python3
+complete -o nospace -F __gamer_configure_autocomplete ./configure.py python python3


### PR DESCRIPTION
Solve problem in gamer-project/gamer#357 about the missing trailing space side effect.
I found an even easier solution with `compopt`.

After attempting to solve the problem by calling `complete` again to switch to another help function and switching back when returning to GAMER, I found that `compopt` can modify the behavior of the currently-executing completion.

Neither ChatGPT nor Copilot provided any clues about this problem. I found the solution in the following docs, just like in the good old days 😄 

Ref: https://www.gnu.org/software/bash/manual/bash.html#Programmable-Completion-Builtins

##### Note

> If a shell function returns 124, and changes the compspec associated with the command on which completion is being attempted (supplied as the first argument when the function is executed), programmable completion restarts from the beginning, with an attempt to find a new compspec for that command.

Cool things to know. This will be an important trick if a dynamical completion is needed.

Ref: https://www.gnu.org/software/bash/manual/bash.html#Programmable-Completion